### PR TITLE
speed up numpy LCA by vectorizing Gram matrix calculation. LCA requires ...

### DIFF
--- a/LCAnumpy/lca.py
+++ b/LCAnumpy/lca.py
@@ -36,13 +36,17 @@ def infer(basis,coeffs,stimuli,eta,lamb,nIter,softThresh,adapt):
     s = np.zeros((numStim,numDict))
     b = np.zeros((numStim,numDict))
     ci = np.zeros((numStim,numDict))
-    c = np.zeros((numDict,numDict))
+    # Calculate c: overlap of basis functions with each other minus identity
+    c = np.dot(basis, basis.T) - np.eye(numDict)
+
+    # c = np.zeros((numDict,numDict))
     #Calculate c: overlap of basis functions with each other minus identity
     #should use symmetry to cut back on time, probably not important
-    for ii in xrange(numDict):
-        for jj in xrange(ii):
-            c[ii,jj] = np.dot(basis[ii],basis[jj])
-            c[jj,ii] = c[ii,jj]
+    # for ii in xrange(numDict):
+    #    for jj in xrange(ii):
+    #        c[ii,jj] = np.dot(basis[ii],basis[jj])
+    #        c[jj,ii] = c[ii,jj]
+
     #b[i,j] is the overlap fromstimuli:i and basis:j
     b = np.dot(stimuli,basis.T)
     thresh = np.mean(np.absolute(b),axis=1)

--- a/timing.py
+++ b/timing.py
@@ -1,6 +1,7 @@
 #This file will time various versions of LCA
 from __future__ import division
 import numpy as np
+import sklearn.preprocessing as skp
 from timeit import default_timer as timer
 
 from LCAnumpy import lca as lcan
@@ -23,6 +24,8 @@ def main():
     numBatch = int(128)
     dataSize = int(256)
     dictsIn = np.random.randn(numDict,dataSize)
+    # LCA requires that dictionary be unit norm
+    dictsIn = skp.normalize(dictsIn, axis=1)
     coeffs = np.random.randn(numBatch,numDict)
     stimuli = np.random.randn(numBatch,dataSize)
     batchCoeffs = np.random.randn(numBatch,numDict)


### PR DESCRIPTION
...unit norm basis function. 
